### PR TITLE
Remain compatible with apache http client

### DIFF
--- a/towel/api/parsers.py
+++ b/towel/api/parsers.py
@@ -48,18 +48,19 @@ class RequestParser(object):
             'application/x-www-form-urlencoded')
 
         handlers = {
-            'application/x-www-form-urlencoded': self.parse_form,
-            'multipart/form-data': self.parse_form,
-            'application/json': self.parse_json,
-            }
+            r'^application/x-www-form-urlencoded': self.parse_form,
+            r'^multipart/form-data': self.parse_form,
+            r'^application/json': self.parse_json,
+        }
 
-        if content_type not in handlers:
-            return Serializer().serialize({
-                'error': '%r is not supported' % content_type,
-                }, request=request, status=httplib.UNSUPPORTED_MEDIA_TYPE,
-                output_format=request.GET.get('format'))
+        for pattern, hander in handlers.items():
+            if re.match(pattern, content_type):
+                return handlers[pattern](request)
 
-        return handlers[content_type](request)
+        return Serializer().serialize({
+            'error': '%r is not supported' % content_type,
+            }, request=request, status=httplib.UNSUPPORTED_MEDIA_TYPE,
+            output_format=request.GET.get('format'))
 
     def parse_form(self, request):
         """


### PR DESCRIPTION
The introduced parser handling for different request bodies generates some problems with certain http libraries as the apache http client (http://hc.apache.org/httpcomponents-client-ga/). For no obvois reasons the library also sends a charset and i get an error like: 

'application/x-www-form-urlencoded; charset=UTF-8' is not supported

This patch solves the problem by only matching the first part of content type to find a corresponding parser. str.startswith would be faster, but regex is more extendable. What do you think?
