### PR TITLE
Using transaction.atomic because of Django 1.8

### DIFF
--- a/towel/modelview.py
+++ b/towel/modelview.py
@@ -781,7 +781,7 @@ class ModelView(object):
                 request, instance=new_instance, change=change)
 
             if all_valid(formsets.values()) and form_validated:
-                with transaction.commit_on_success():
+                with transaction.atomic():
                     self.save_model(request, new_instance, form, change=change)
                     form.save_m2m()
                     self.save_formsets(request, form, formsets, change=change)


### PR DESCRIPTION
commit_on_success from django.db.transaction was removed in Django 1.8