### PR TITLE
docs: Fix simple typo, existant -> existent

### DIFF
--- a/towel/templatetags/towel_form_tags.py
+++ b/towel/templatetags/towel_form_tags.py
@@ -91,7 +91,7 @@ def form_errors(parser, token):
 
         {% form_errors form formset1 formset2 %}
 
-    Silently ignores non-existant variables.
+    Silently ignores non-existent variables.
     """
 
     tokens = token.split_contents()
@@ -157,7 +157,7 @@ def form_warnings(parser, token):
 
         {% form_warnings form formset1 formset2 %}
 
-    Silently ignores non-existant variables.
+    Silently ignores non-existent variables.
     """
 
     tokens = token.split_contents()


### PR DESCRIPTION
There is a small typo in towel/templatetags/towel_form_tags.py.

Should read `existent` rather than `existant`.

