### PR TITLE
docs: Fix a few typos

### DIFF
--- a/towel/forms.py
+++ b/towel/forms.py
@@ -496,7 +496,7 @@ class WarningsForm(forms.BaseForm):
       warnings, if those warnings have not been explicitly ignored (by checking
       a checkbox or by passing ``ignore_warnings=True`` to ``is_valid()``.
     * An additional form field named ``ignore_warnings`` is available - this
-      field should only be displayed if ``WarningsForm.warnings`` is non-emtpy.
+      field should only be displayed if ``WarningsForm.warnings`` is non-empty.
     """
 
     def __init__(self, *args, **kwargs):

--- a/towel/managers.py
+++ b/towel/managers.py
@@ -12,7 +12,7 @@ def normalize_query(
     normspace=re.compile(r"\s{2,}").sub,
 ):
     """
-    Splits the query string in invidual keywords, getting rid of unecessary
+    Splits the query string in individual keywords, getting rid of unnecessary
     spaces and grouping quoted words together.
 
     Example::

--- a/towel/templatetags/towel_form_tags.py
+++ b/towel/templatetags/towel_form_tags.py
@@ -89,7 +89,7 @@ def form_errors(parser, token):
 
         {% form_errors form formset1 formset2 %}
 
-    Silently ignores non-existant variables.
+    Silently ignores non-existent variables.
     """
 
     tokens = token.split_contents()
@@ -155,7 +155,7 @@ def form_warnings(parser, token):
 
         {% form_warnings form formset1 formset2 %}
 
-    Silently ignores non-existant variables.
+    Silently ignores non-existent variables.
     """
 
     tokens = token.split_contents()

--- a/towel/templatetags/towel_region.py
+++ b/towel/templatetags/towel_region.py
@@ -33,7 +33,7 @@ def region(parser, token):
     The identifier should be a short string which is unique for the whole
     project, or at least for a given view. It is used to identify the region
     when live-updating, it should therefore be usable as a part of a HTML
-    ``id`` attribute. The identifer should not start with an underscore,
+    ``id`` attribute. The identifier should not start with an underscore,
     those names are reserved for internal bookkeeping.
 
     ``fields`` is a comma-separated list of fields (or other identifiers)


### PR DESCRIPTION
There are small typos in:
- towel/forms.py
- towel/managers.py
- towel/templatetags/towel_form_tags.py
- towel/templatetags/towel_region.py

Fixes:
- Should read `existent` rather than `existant`.
- Should read `unnecessary` rather than `unecessary`.
- Should read `individual` rather than `invidual`.
- Should read `identifier` rather than `identifer`.
- Should read `empty` rather than `emtpy`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md